### PR TITLE
Upgrade to babel 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .DS_Store
+yarn.lock
+package-lock.json
+npm-shrinkwrap.json

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-module.exports = {
-  plugins: [
-    require('@babel/plugin-proposal-class-properties'),
-    require('@babel/plugin-transform-flow-strip-types')
-  ]
-}
+module.exports = function(api, options){
+  return {
+    plugins: [
+      [require('@babel/plugin-proposal-class-properties'), {loose: options.loose}],
+      require('@babel/plugin-transform-flow-strip-types')
+    ]
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   plugins: [
-    require('babel-plugin-transform-class-properties'),
-    require('babel-plugin-syntax-flow'),
-    require('babel-plugin-transform-flow-strip-types')
+    require('@babel/plugin-proposal-class-properties'),
+    require('@babel/plugin-transform-flow-strip-types')
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/yyx990803/babel-preset-flow-vue/issues"
   },
   "homepage": "https://github.com/yyx990803/babel-preset-flow-vue#readme",
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "homepage": "https://github.com/yyx990803/babel-preset-flow-vue#readme",
   "dependencies": {
-    "babel-plugin-syntax-flow": "^6.8.0",
-    "babel-plugin-transform-class-properties": "^6.8.0",
-    "babel-plugin-transform-flow-strip-types": "^6.8.0"
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-transform-flow-strip-types": "^7.0.0"
   }
 }


### PR DESCRIPTION
- Upgrade dependencies to `babel` v7
- Remove `babel-plugin-syntax-flow` since it's included in [`@babel/plugin-transform-flow-strip-types`](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-flow-strip-types/src/index.js#L2)
- Add support for the [`loose` option of `@babel/plugin-proposal-class-properties`](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties#loose)
- Add `@babel/core` as a peer dependency